### PR TITLE
Pal/test init

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,16 @@
 fn main() {
     println!("Hello, world!");
 }
+
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_example() {
+        assert_eq!(main(), "Hello ");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 fn main() {
-    println!("Hello, world!");
+
+}
+
+fn version_info() -> &'static str {
+    "bcl2fastr beta version"
 }
 
 
@@ -10,7 +14,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_example() {
-        assert_eq!(main(), "Hello ");
+    fn test_version_info() {
+        assert_eq!(version_info(), "bcl2fastr beta version");
     }
 }


### PR DESCRIPTION
added some simple example test for `main.rs`. Test can be performed by running the `cargo test`

**Note:** This test/code so far is mainly for example, we'll take this out once we get some more tests established. (I'm guessing that there is an established way to print out version / general package info)