### PR TITLE
Seek into file

### DIFF
--- a/src/cbcl_header_decoder.rs
+++ b/src/cbcl_header_decoder.rs
@@ -65,7 +65,6 @@ impl CBCLHeader {
 pub fn cbcl_header_decoder(cbcl_path : &Path) -> CBCLHeader {
     let f = File::open(cbcl_path).unwrap();
     let cbcl_header = CBCLHeader::from_reader(f).unwrap();
-    println!("{:#?}", cbcl_header);
     return cbcl_header;
 }
 

--- a/src/extract_reads.rs
+++ b/src/extract_reads.rs
@@ -137,3 +137,19 @@ pub fn extract_reads(locs_path: &Path, run_info_path: &Path, lane_path: &Path, t
 
     extract_base_matrix(&headers, &cbcl_paths, tile_idces)
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_reads() {
+        let locs_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/Data/Intensities/s.locs");
+        let run_info_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/RunInfo.xml");
+        let lane_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/Data/Intensities/BaseCalls/L001");
+        let tile_idces = vec![0, 1];
+
+        extract_reads(locs_path, run_info_path, lane_path, tile_idces).unwrap()
+    }
+}

--- a/src/filter_decoder.rs
+++ b/src/filter_decoder.rs
@@ -30,7 +30,6 @@ impl Filter {
 pub fn filter_decoder(filter_path: &Path) -> Filter {
     let f = File::open(filter_path).unwrap();
     let filter = Filter::from_reader(f).unwrap();
-    println!("{:#?}", filter);
     return filter;
 }
 

--- a/src/locs_decoder.rs
+++ b/src/locs_decoder.rs
@@ -32,7 +32,6 @@ impl Locs {
 pub fn locs_decoder(locs_path: &Path) -> Locs {
     let f = File::open(locs_path).unwrap();
     let locs = Locs::from_reader(f).unwrap();
-    println!("{:#?}", locs);
     return locs;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,5 +17,5 @@ fn main() {
     let run_info_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/RunInfo.xml");
     let lane_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/Data/Intensities/BaseCalls/L001");
 
-    extract_reads::extract_reads(locs_path, run_info_path, lane_path, vec![0]);
+    extract_reads::extract_reads(locs_path, run_info_path, lane_path, vec![0, 1]).unwrap();
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,10 +85,8 @@ pub struct RunInfo {
 
 
 pub fn parse_run_info(run_info_path: &Path) -> RunInfo {
-    println!("reading file {}", run_info_path.display());
     let run_xml = fs::read_to_string(run_info_path).expect("error reading the file");
     let runinfo : RunInfo = from_reader(run_xml.as_bytes()).unwrap();
-    println!("{:#?}", runinfo);
     return runinfo
 }
 


### PR DESCRIPTION
Changed the `extract_reads` code that it properly seeks into the cbcl file rather than reading the entire thing into memory. Also fixed some code that never worked previously. Need to add tests, although first we might need to add actual output.

Also removing some print statements and commented out code that was causing warnings.

Closes #34 