### PR TITLE
Add rustdoc documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
  - Build the docs:
 
-   `docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items`
+   ```docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items```
 
  - Develop:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
    `docker build --tag=bcl2fastr-dev . # in bcl2fastr top directory`
 
+ - Build the docs:
+
+  The first command builds the documentation for the dependencies and only needs to be run occasionally. The second builds richer documentation for `bcl2fastr`.
+
+   ```
+   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc
+   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --no-deps --document-private-items
+   ```
+
  - Develop:
 
    `docker run -it -v <your local bcl2fastr path>:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev`

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
  - Build the docs:
 
-   ```
-   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items
-   ```
+   `docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items`
 
  - Develop:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
  - Build the docs:
 
-   ```docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items```
+   `docker run -v <your local bcl2fastr path>:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items`
 
  - Develop:
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,8 @@
 
  - Build the docs:
 
-  The first command builds the documentation for the dependencies and only needs to be run occasionally. The second builds richer documentation for `bcl2fastr`.
-
    ```
-   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc
-   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --no-deps --document-private-items
+   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --document-private-items
    ```
 
  - Develop:

--- a/src/cbcl_header_decoder.rs
+++ b/src/cbcl_header_decoder.rs
@@ -7,6 +7,7 @@ use std::{
 
 
 #[derive(Debug, PartialEq)]
+/// Represents the header information from a CBCL file
 pub struct CBCLHeader {
     pub cbcl_path: PathBuf,
     pub version: u16,

--- a/src/extract_reads.rs
+++ b/src/extract_reads.rs
@@ -1,3 +1,5 @@
+//! Extract and decompress a set of tiles from a vector of cbcl files.
+
 extern crate flate2;
 extern crate glob;
 

--- a/src/filter_decoder.rs
+++ b/src/filter_decoder.rs
@@ -1,3 +1,5 @@
+//! Read `*.filter` files into vectors of boolean values.
+
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::{
     fs::File,
@@ -7,11 +9,19 @@ use std::{
 
 
 #[derive(Debug, PartialEq)]
+/// A filter is a vector of booleans representing whether each cluster
+/// in a tile has passed quality filtering.
 pub struct Filter {
     pub bin_mask: Vec<bool>
 }
 
 impl Filter {
+    /// Creates a `Filter` struct from a file reader
+    /// 
+    /// Format of a `.filter` file:
+    ///  1. Two `u32` containing header info (ignored)
+    ///  2. `u32` representing the number of clusters
+    ///  3. `[u8; num_clusters]` of true/false (1 or 0) values
     fn from_reader(mut rdr: impl Read) -> io::Result<Self> {
         let _ = rdr.read_u64::<LittleEndian>()?;
         let num_clusters = rdr.read_u32::<LittleEndian>()? as usize;
@@ -25,6 +35,8 @@ impl Filter {
     }
 }
 
+
+/// Decode a `.filter` file into a `Filter` struct or panic
 pub fn filter_decoder(filter_path: &Path) -> Filter {
     let f = match File::open(filter_path) {
         Err(e) => panic!(

--- a/src/locs_decoder.rs
+++ b/src/locs_decoder.rs
@@ -7,6 +7,7 @@ use std::{
 
 
 #[derive(Debug, PartialEq)]
+/// Each element is an array of [x, y] locations
 pub struct Locs {
     pub locs: Vec<[f32; 2]>,
 }

--- a/src/locs_decoder.rs
+++ b/src/locs_decoder.rs
@@ -1,3 +1,5 @@
+//! Reads `*.locs` files into vectors of float arrays
+
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::{
     fs::File,
@@ -7,13 +9,19 @@ use std::{
 
 
 #[derive(Debug, PartialEq)]
-/// Each element is an array of [x, y] locations
+/// Each element is an array of [x, y] locations, one for each cluster in a tile
 pub struct Locs {
     pub locs: Vec<[f32; 2]>,
 }
 
 
 impl Locs {
+    /// Creates a `Locs` struct from a file reader
+    /// 
+    /// Format of a `.locs` file: 
+    ///  1. Two `u32` containing header info (ignored)
+    ///  2. `u32` representing number of clusters (locations)
+    ///  3. `[f32; 2 * num_clusters]` of [x, y] pairs
     fn from_reader(mut rdr: impl Read) -> io::Result<Self> {
         let _ = rdr.read_u64::<LittleEndian>()?;
         let num_clusters = rdr.read_u32::<LittleEndian>()? as usize;
@@ -33,6 +41,7 @@ impl Locs {
 }
 
 
+/// Decode a `.locs` file into a `Locs` struct or panic
 pub fn locs_decoder(locs_path: &Path) -> Locs {
     let f = match File::open(locs_path) {
         Err(e) => panic!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+//! bcl2fastr is a program for efficient multi-threaded demultiplexing of large
+//! sequencing runs (specifically from the NovaSeq instrument).
+
 use std::path::Path;
 
 mod run_info_parser;
@@ -6,7 +9,7 @@ mod locs_decoder;
 mod cbcl_header_decoder;
 mod extract_reads;
 
-/// Main function parses command line arguments and runs demux
+/// Parses command line arguments and runs demux
 fn main() {
     let locs_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/Data/Intensities/s.locs");
     let run_info_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/RunInfo.xml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod locs_decoder;
 mod cbcl_header_decoder;
 mod extract_reads;
 
+/// Main function parses command line arguments and runs demux
 fn main() {
     let locs_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/Data/Intensities/s.locs");
     let run_info_path = Path::new("test_data/190414_A00111_0296_AHJCWWDSXX/RunInfo.xml");

--- a/src/run_info_parser.rs
+++ b/src/run_info_parser.rs
@@ -1,3 +1,6 @@
+//! Deserializes the `RunInfo.xml` file from a NovaSeq run into a useful struct
+//! of information about the sequencing run.
+
 use std::{
     fs,
     path::Path,
@@ -99,6 +102,7 @@ pub struct Tiles {
 }
 
 
+/// Parse a `RunInfo.xml` file into a `RunInfo` struct or panic
 pub fn parse_run_info(run_info_path: &Path) -> RunInfo {
     let run_xml = match fs::read_to_string(run_info_path) {
         Err(e) => panic!(


### PR DESCRIPTION
Rust has a nice auto-documentation feature: comments that start with `///` will turn into documentation in a nice website. `cargo doc` will also pull in the documentation for all the dependencies, which is nice.

The first command builds the documentation for the dependencies and only needs to be run occasionally. The second builds richer documentation for `bcl2fastr`.

   ```
   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc
   docker run -v `pwd`:/usr/src/bcl2fastr --rm --name bcl2fastr-dev bcl2fastr-dev cargo doc --no-deps --document-private-items
   ```

I just added a few for the moment but it'd be good to have a well-documented resource for development purposes.
